### PR TITLE
Only cache objects managed by operator

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -68,5 +68,5 @@ vars:
 #    name: webhook-service
 
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: icr.io/ibm/ibm-object-csi-driver-operator
-  newTag: v0.1.11
+  newName: icr.io/bhagya-test/ibm-object-csi-driver-operator
+  newTag: nov262024
 commonLabels:
-  app.kubernetes.io/managed-by: kustomize
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
+  app.kubernetes.io/part-of: ibm-object-csi-driver

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: icr.io/bhagya-test/ibm-object-csi-driver-operator
-  newTag: nov262024
+  newName: icr.io/ibm/ibm-object-csi-driver-operator
+  newTag: v0.1.14
 commonLabels:
   app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
   app.kubernetes.io/part-of: ibm-object-csi-driver

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -99,9 +99,11 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 500Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      imagePullSecrets:
+      - name: bha-secret

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -105,5 +105,3 @@ spec:
             memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
-      imagePullSecrets:
-      - name: bha-secret

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../scorecard
 
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
 - monitor.yaml
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,5 +18,5 @@ resources:
 - auth_proxy_client_clusterrole.yaml
 
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator

--- a/config/samples/csi_v1alpha1_ibmobjectcsi.yaml
+++ b/config/samples/csi_v1alpha1_ibmobjectcsi.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: ibm-object-csi
     app.kubernetes.io/instance: ibm-object-csi
+    app.kubernetes.io/part-of: ibm-object-csi-driver
+    app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
     release: v1.0.0
 spec:
   # controller is a deployment with ibm-object-csi-controller container

--- a/config/samples/csi_v1alpha1_recoverstalevolume.yaml
+++ b/config/samples/csi_v1alpha1_recoverstalevolume.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/name: recoverstalevolume
     app.kubernetes.io/instance: recoverstalevolume-sample
+    app.kubernetes.io/part-of: ibm-object-csi-driver
+    app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
   name: recoverstalevolume-sample
   namespace: ibm-object-csi-operator
 spec:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 - csi_v1alpha1_ibmobjectcsi.yaml
 - csi_v1alpha1_recoverstalevolume.yaml
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/resource_req_limit_configmap.yaml
+++ b/config/samples/resource_req_limit_configmap.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: cos-csi-driver-configmap
   namespace: ibm-object-csi-operator
+  labels:
+    app.kubernetes.io/part-of: ibm-object-csi-driver
+    app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
 data:
   ReconcileStorageClasses: "true"
   #Resource Requests per container

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -14,6 +14,6 @@ patchesJson6902:
     kind: Configuration
     name: config
 commonLabels:
-  app.kubernetes.io/part-of: ibm-object-csi-driver-operator
-  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: ibm-object-csi-driver
+  app.kubernetes.io/managed-by: ibm-object-csi-driver-operator
 #+kubebuilder:scaffold:patchesJson6902

--- a/main.go
+++ b/main.go
@@ -23,18 +23,21 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	objectdriverv1alpha1 "github.com/IBM/ibm-object-csi-driver-operator/api/v1alpha1"
 	"github.com/IBM/ibm-object-csi-driver-operator/controllers"
+	"github.com/IBM/ibm-object-csi-driver-operator/controllers/constants"
 	"github.com/IBM/ibm-object-csi-driver-operator/controllers/util/common"
 	//+kubebuilder:scaffold:imports
 )
@@ -75,6 +78,9 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "af88e983.csi.ibm.com",
+		Cache: cache.Options{
+			DefaultLabelSelector: labels.SelectorFromSet(constants.CommonCSIResourceLabels),
+		},
 
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the


### PR DESCRIPTION
Configure controller-runtime cache to only cache objects that have the commonly used labels set by the operator.
With that the operator will build up a cache for only the resources it manages.

Normally controller-runtime would build up a cache for all resources the client interacts with.
This is especially a problem for large cluster as then the operator would cache all Deployments and DaemonSets, which would then drastically increase memory usage.

With this change we can keep memory usage relatively small and also stable regardless the size of the cluster
