### PR TITLE
Ensure error is not ommitted

### DIFF
--- a/controllers/util/common/common.go
+++ b/controllers/util/common/common.go
@@ -271,7 +271,8 @@ func (ch *ControllerHelper) GetClusterInfo(inConfig rest.Config) error {
 	}
 
 	if k8sClient != nil {
-		list, err := k8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		var list *corev1.NodeList
+		list, err = k8sClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err == nil {
 			nodes = *list
 		}


### PR DESCRIPTION
We observed panics at https://github.com/IBM/ibm-object-csi-driver-operator/blob/1a5ddd2f042154644d473923f4b742ae9cb0e554/controllers/util/common/common.go#L287
Which indicates that the nodes object might be "empty".

From looking at the code it's most likely that the List call with k8sClient failed.
However as the err variable is initiated only in the scope of this if clause the latter error check did not catch the error
