### PR TITLE
Add mount-s3 storage class support

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -90,9 +90,9 @@ const (
 	RcloneStorageClass       = StorageClassPrefix + "-rclone"
 	S3fsRetainStorageClass   = StorageClassPrefix + "-s3fs-retain"
 	S3fsStorageClass         = StorageClassPrefix + "-s3fs"
-	
-	S3MounterRetainStorageClass = StorageClassPrefix + "-s3mounter-retain"
-	S3MounterStorageClass       = StorageClassPrefix + "-s3mounter"
+
+	MountS3RetainStorageClass = StorageClassPrefix + "-mount-s3-retain"
+	MountS3StorageClass       = StorageClassPrefix + "-mount-s3"
 
 	S3ProviderIBM    = "ibm-cos"
 	S3ProviderAWS    = "aws"

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -90,6 +90,9 @@ const (
 	RcloneStorageClass       = StorageClassPrefix + "-rclone"
 	S3fsRetainStorageClass   = StorageClassPrefix + "-s3fs-retain"
 	S3fsStorageClass         = StorageClassPrefix + "-s3fs"
+	
+	S3MounterRetainStorageClass = StorageClassPrefix + "-s3mounter-retain"
+	S3MounterStorageClass       = StorageClassPrefix + "-s3mounter"
 
 	S3ProviderIBM    = "ibm-cos"
 	S3ProviderAWS    = "aws"

--- a/controllers/ibmobjectcsi_controller.go
+++ b/controllers/ibmobjectcsi_controller.go
@@ -610,6 +610,16 @@ func (r *IBMObjectCSIReconciler) getStorageClasses(instance *crutils.IBMObjectCS
 				COSStorageClass: sc,
 			})
 			k8sSCs = append(k8sSCs, s3fsK8sSc)
+
+			// S3 Mounter
+			s3MounterK8sSc := instance.GenerateS3MounterSC(crutils.SCInputParams{
+				ReclaimPolicy:   rp,
+				S3Provider:      s3Provider,
+				Region:          requiredRegion,
+				COSEndpoint:     cosEP,
+				COSStorageClass: sc,
+			})
+			k8sSCs = append(k8sSCs, s3MounterK8sSc)
 		}
 	}
 	return k8sSCs

--- a/controllers/ibmobjectcsi_controller.go
+++ b/controllers/ibmobjectcsi_controller.go
@@ -612,14 +612,15 @@ func (r *IBMObjectCSIReconciler) getStorageClasses(instance *crutils.IBMObjectCS
 			k8sSCs = append(k8sSCs, s3fsK8sSc)
 
 			// S3 Mounter
-			s3MounterK8sSc := instance.GenerateS3MounterSC(crutils.SCInputParams{
+			mountS3K8sSc := instance.GenerateMountS3SC(crutils.SCInputParams{
 				ReclaimPolicy:   rp,
 				S3Provider:      s3Provider,
 				Region:          requiredRegion,
 				COSEndpoint:     cosEP,
 				COSStorageClass: sc,
 			})
-			k8sSCs = append(k8sSCs, s3MounterK8sSc)
+			k8sSCs = append(k8sSCs, mountS3K8sSc)
+
 		}
 	}
 	return k8sSCs

--- a/controllers/ibmobjectcsi_controller_test.go
+++ b/controllers/ibmobjectcsi_controller_test.go
@@ -498,15 +498,15 @@ var (
 		},
 	}
 
-	s3MounterSC = &storagev1.StorageClass{
+	mountS3SC = &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-standard-s3mounter", constants.StorageClassPrefix),
+			Name:   fmt.Sprintf("%s-standard-mount-s3", constants.StorageClassPrefix),
 			Labels: constants.CommonCSIResourceLabels,
 		},
 		Provisioner:   constants.DriverName,
 		ReclaimPolicy: &reclaimPolicyDelete,
 		Parameters: map[string]string{
-			"mounter":            "s3mounter",
+			"mounter":            "mount-s3",
 			"client":             "awss3",
 			"cosEndpoint":        "https://s3.us-east-2.amazonaws.com",
 			"locationConstraint": "us-east-2",
@@ -515,15 +515,15 @@ var (
 		},
 	}
 
-	s3MounterRetainSC = &storagev1.StorageClass{
+	mountS3RetainSC = &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-standard-s3mounter-retain", constants.StorageClassPrefix),
+			Name:   fmt.Sprintf("%s-standard-mount-s3-retain", constants.StorageClassPrefix),
 			Labels: constants.CommonCSIResourceLabels,
 		},
 		Provisioner:   constants.DriverName,
 		ReclaimPolicy: &reclaimPolicyRetain,
 		Parameters: map[string]string{
-			"mounter":            "s3mounter",
+			"mounter":            "mount-s3",
 			"client":             "awss3",
 			"cosEndpoint":        "https://s3.us-east-2.amazonaws.com",
 			"locationConstraint": "us-east-2",
@@ -980,8 +980,8 @@ func TestIBMObjectCSIReconcile(t *testing.T) {
 				rCloneRetainSC,
 				s3fsSC,
 				s3fsRetainSC,
-				s3MounterSC,
-				s3MounterRetainSC,
+				mountS3SC,
+				mountS3RetainSC,
 			},
 			clientFunc: func(objs []runtime.Object) client.WithWatch {
 				return fakedelete.NewClientBuilder().WithRuntimeObjects(objs...).Build()

--- a/controllers/ibmobjectcsi_controller_test.go
+++ b/controllers/ibmobjectcsi_controller_test.go
@@ -497,6 +497,40 @@ var (
 			"csi.storage.k8s.io/node-publish-secret-namespace": "${pvc.namespace}",
 		},
 	}
+
+	s3MounterSC = &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-standard-s3mounter", constants.StorageClassPrefix),
+			Labels: constants.CommonCSIResourceLabels,
+		},
+		Provisioner:   constants.DriverName,
+		ReclaimPolicy: &reclaimPolicyDelete,
+		Parameters: map[string]string{
+			"mounter":            "s3mounter",
+			"client":             "awss3",
+			"cosEndpoint":        "https://s3.us-east-2.amazonaws.com",
+			"locationConstraint": "us-east-2",
+			"csi.storage.k8s.io/node-publish-secret-name":      "${pvc.annotations['cos.csi.driver/secret']}",
+			"csi.storage.k8s.io/node-publish-secret-namespace": "${pvc.namespace}",
+		},
+	}
+
+	s3MounterRetainSC = &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-standard-s3mounter-retain", constants.StorageClassPrefix),
+			Labels: constants.CommonCSIResourceLabels,
+		},
+		Provisioner:   constants.DriverName,
+		ReclaimPolicy: &reclaimPolicyRetain,
+		Parameters: map[string]string{
+			"mounter":            "s3mounter",
+			"client":             "awss3",
+			"cosEndpoint":        "https://s3.us-east-2.amazonaws.com",
+			"locationConstraint": "us-east-2",
+			"csi.storage.k8s.io/node-publish-secret-name":      "${pvc.annotations['cos.csi.driver/secret']}",
+			"csi.storage.k8s.io/node-publish-secret-namespace": "${pvc.namespace}",
+		},
+	}
 )
 
 func TestIBMObjectCSIReconcile(t *testing.T) {
@@ -946,6 +980,8 @@ func TestIBMObjectCSIReconcile(t *testing.T) {
 				rCloneRetainSC,
 				s3fsSC,
 				s3fsRetainSC,
+				s3MounterSC,
+				s3MounterRetainSC,
 			},
 			clientFunc: func(objs []runtime.Object) client.WithWatch {
 				return fakedelete.NewClientBuilder().WithRuntimeObjects(objs...).Build()

--- a/controllers/internal/crutils/static_resource_generator.go
+++ b/controllers/internal/crutils/static_resource_generator.go
@@ -311,3 +311,37 @@ func (c *IBMObjectCSI) GenerateRcloneSC(scInputParams SCInputParams) *storagev1.
 		},
 	}
 }
+
+// GenerateS3MounterSC ...
+func (c *IBMObjectCSI) GenerateS3MounterSC(scInputParams SCInputParams) *storagev1.StorageClass {
+	var storageClassName, locationConstraint string
+
+	if scInputParams.S3Provider == constants.S3ProviderIBM {
+		locationConstraint = fmt.Sprintf("%s-%s", scInputParams.Region, scInputParams.COSStorageClass)
+	} else {
+		locationConstraint = scInputParams.Region
+	}
+
+	// "ibm-object-storage-standard-s3mounter"
+	storageClassName = fmt.Sprintf("%s-%s-s3mounter", constants.StorageClassPrefix, scInputParams.COSStorageClass)
+	if scInputParams.ReclaimPolicy == corev1.PersistentVolumeReclaimRetain {
+		storageClassName = fmt.Sprintf("%s-%s", storageClassName, constants.RetainPolicyTag) // "ibm-object-storage-standard-s3mounter-retain"
+	}
+
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   storageClassName,
+			Labels: constants.CommonCSIResourceLabels,
+		},
+		Provisioner:   constants.DriverName,
+		ReclaimPolicy: &scInputParams.ReclaimPolicy,
+		Parameters: map[string]string{
+			"mounter":            "s3mounter",
+			"client":             "awss3",
+			"cosEndpoint":        scInputParams.COSEndpoint,
+			"locationConstraint": locationConstraint,
+			"csi.storage.k8s.io/node-publish-secret-name":      "${pvc.annotations['cos.csi.driver/secret']}",
+			"csi.storage.k8s.io/node-publish-secret-namespace": "${pvc.namespace}",
+		},
+	}
+}

--- a/controllers/internal/crutils/static_resource_generator.go
+++ b/controllers/internal/crutils/static_resource_generator.go
@@ -328,6 +328,20 @@ func (c *IBMObjectCSI) GenerateMountS3SC(scInputParams SCInputParams) *storagev1
 		storageClassName = fmt.Sprintf("%s-%s", storageClassName, constants.RetainPolicyTag) // "ibm-object-storage-standard-s3mounter-retain"
 	}
 
+	mountOptions := []string{
+		"log-directory=/data/s3mount/logs",
+		"force-path-style",
+		"upload-checksums=off",
+		"allow-delete",
+		"allow-overwrite",
+		"read-part-size=16777216",
+		"write-part-size=16777216",
+		"maximum-throughput-gbps=10",
+		"metadata-ttl=60",
+		"cache=/tmp/mounts3-cache",
+		"max-cache-size=256",
+	}
+
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   storageClassName,
@@ -335,6 +349,7 @@ func (c *IBMObjectCSI) GenerateMountS3SC(scInputParams SCInputParams) *storagev1
 		},
 		Provisioner:   constants.DriverName,
 		ReclaimPolicy: &scInputParams.ReclaimPolicy,
+		MountOptions:  mountOptions,
 		Parameters: map[string]string{
 			"mounter":            "mount-s3",
 			"client":             "awss3",

--- a/controllers/internal/crutils/static_resource_generator.go
+++ b/controllers/internal/crutils/static_resource_generator.go
@@ -313,7 +313,7 @@ func (c *IBMObjectCSI) GenerateRcloneSC(scInputParams SCInputParams) *storagev1.
 }
 
 // GenerateS3MounterSC ...
-func (c *IBMObjectCSI) GenerateS3MounterSC(scInputParams SCInputParams) *storagev1.StorageClass {
+func (c *IBMObjectCSI) GenerateMountS3SC(scInputParams SCInputParams) *storagev1.StorageClass {
 	var storageClassName, locationConstraint string
 
 	if scInputParams.S3Provider == constants.S3ProviderIBM {
@@ -323,7 +323,7 @@ func (c *IBMObjectCSI) GenerateS3MounterSC(scInputParams SCInputParams) *storage
 	}
 
 	// "ibm-object-storage-standard-s3mounter"
-	storageClassName = fmt.Sprintf("%s-%s-s3mounter", constants.StorageClassPrefix, scInputParams.COSStorageClass)
+	storageClassName = fmt.Sprintf("%s-%s-mounts3", constants.StorageClassPrefix, scInputParams.COSStorageClass)
 	if scInputParams.ReclaimPolicy == corev1.PersistentVolumeReclaimRetain {
 		storageClassName = fmt.Sprintf("%s-%s", storageClassName, constants.RetainPolicyTag) // "ibm-object-storage-standard-s3mounter-retain"
 	}
@@ -336,7 +336,7 @@ func (c *IBMObjectCSI) GenerateS3MounterSC(scInputParams SCInputParams) *storage
 		Provisioner:   constants.DriverName,
 		ReclaimPolicy: &scInputParams.ReclaimPolicy,
 		Parameters: map[string]string{
-			"mounter":            "s3mounter",
+			"mounter":            "mount-s3",
 			"client":             "awss3",
 			"cosEndpoint":        scInputParams.COSEndpoint,
 			"locationConstraint": locationConstraint,


### PR DESCRIPTION
## Describe your changes
Added a new storage class for mount-s3 mounter alongside the existing rclone and s3fs storage classes.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have made sure existing UTs are not impacted
- [ ] I have executed all necessary linter and made sure internal pipeline/travis is not broken
