### PR TITLE
[Please don't merge, generated by RAVEN bot] : fix: Security updates for ibm/ibm-object-csi-driver-operator - Issue #117915

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-object-csi-driver-operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11


### PR DESCRIPTION
## CVE Security Fixes for Issue #117915

### Image: `ibm/ibm-object-csi-driver-operator`

### Fixed CVEs:


### Go Version Info:
- Current Version: 1.26.4
- Upgrade Required: False
- Recommended Version: 1.26.4
- Reason: Current Go version 1.26.4 is up to date


### Additional Actions:
- Go mod tidy executed: ✅


---
*Generated by RAVEN BOT*

---
*Generated by RAVEN BOT*