### PR TITLE
remove max_dirty_data=5120 from s3fs StorageClass mount options

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.5'
 
       - name: Install bc
         run: sudo apt-get update -qq && sudo apt-get install -y bc

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ metadata:
 provisioner: cos.s3.csi.ibm.io
 mountOptions:
     - "multipart_size=62"
-    - "max_dirty_data=51200"
     - "parallel_count=8"
     - "max_stat_cache_size=100000"
     - "retries=5"

--- a/controllers/internal/crutils/static_resource_generator.go
+++ b/controllers/internal/crutils/static_resource_generator.go
@@ -261,7 +261,6 @@ func (c *IBMObjectCSI) GenerateS3fsSC(scInputParams SCInputParams) *storagev1.St
 	mountOptions := []string{
 		"multipart_size=52",
 		"multireq_max=20",
-		"max_dirty_data=5120",
 		"parallel_count=20",
 		"max_stat_cache_size=100000",
 		"retries=5",


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have made sure existing UTs are not impacted
- [ ] I have executed all necessary linter and made sure internal pipeline/travis is not broken
